### PR TITLE
Allow networkx 2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 353879ddf7483f4621872c49cd9bc8a0ad1c3154ac0670b70799922f4cb899e8
 
 build:
-  number: 0
+  number: 1
   script:
     - python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
@@ -33,7 +33,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - scipy >=0.17
     - matplotlib >=1.3.1
-    - networkx >=1.8,<2.0
+    - networkx >=1.8
     - pillow >=2.1.0
     - dask >=0.5
     - pywavelets >=0.4.0


### PR DESCRIPTION
As was done in the upstream (conda-forge repo)[https://github.com/conda-forge/scikit-image-feedstock/commit/fb9521852d11c1c744828b78593961c09bcbe53c]

Also bump the build number so this build takes precedence.

I explained it further here: https://github.com/ContinuumIO/anaconda-recipes/issues/135#issuecomment-355567110