### PR TITLE
update to 0.14.2

### DIFF
--- a/recipe/0001-_marching_cubes_lewiner_cy-mark-char-as-signed.patch
+++ b/recipe/0001-_marching_cubes_lewiner_cy-mark-char-as-signed.patch
@@ -1,0 +1,35 @@
+From 185018b2c8ccafd2602087a4e21f746e0616510f Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 11 Dec 2018 16:19:55 -0600
+Subject: [PATCH 1/2] _marching_cubes_lewiner_cy: mark char as signed
+
+xref: https://github.com/scikit-image/scikit-image/issues/2982
+---
+ skimage/measure/_marching_cubes_lewiner_cy.pyx | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/skimage/measure/_marching_cubes_lewiner_cy.pyx b/skimage/measure/_marching_cubes_lewiner_cy.pyx
+index 502d29a..47c11d9 100644
+--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
++++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
+@@ -748,7 +748,7 @@ cdef class Lut:
+     This class defines functions to look up values using 1, 2 or 3 indices.
+     """ 
+     
+-    cdef char* VALUES
++    cdef signed char* VALUES
+     cdef int L0 # Length
+     cdef int L1 # size of tuple
+     cdef int L2 # size of tuple in tuple (if any)
+@@ -769,7 +769,7 @@ cdef class Lut:
+         array = array.ravel()
+         cdef int n, N
+         N = self.L0 * self.L1 * self.L2
+-        self.VALUES = <char *> malloc(N * sizeof(char)) 
++        self.VALUES = <signed char *> malloc(N * sizeof(signed char))
+         for n in range(N):
+             self.VALUES[n] = array[n]
+     
+-- 
+2.19.1
+

--- a/recipe/0002-Mark-some-tests-as-xfail-if-numpy-uses-mkl.patch
+++ b/recipe/0002-Mark-some-tests-as-xfail-if-numpy-uses-mkl.patch
@@ -1,0 +1,91 @@
+From c858d5e860d4e8dd59d2dacfd4b2fb63de13044d Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 11 Dec 2018 21:06:36 -0600
+Subject: [PATCH 2/2] Mark some tests as xfail if numpy uses mkl
+
+---
+ skimage/_shared/testing.py                | 2 ++
+ skimage/exposure/tests/test_exposure.py   | 9 ++++++++-
+ skimage/restoration/tests/test_denoise.py | 5 ++++-
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/skimage/_shared/testing.py b/skimage/_shared/testing.py
+index b75123d..be82887 100644
+--- a/skimage/_shared/testing.py
++++ b/skimage/_shared/testing.py
+@@ -37,6 +37,8 @@ fixture = pytest.fixture
+ # https://docs.python.org/2/library/struct.html
+ arch32 = struct.calcsize("P") * 8 == 32
+ 
++numpy_uses_mkl = any(x.startswith('mkl') for x in
++    np.__config__.get_info('blas_opt')['libraries'])
+ 
+ def assert_less(a, b, msg=None):
+     message = "%r is not lower than %r" % (a, b)
+diff --git a/skimage/exposure/tests/test_exposure.py b/skimage/exposure/tests/test_exposure.py
+index 48e256e..7b63393 100644
+--- a/skimage/exposure/tests/test_exposure.py
++++ b/skimage/exposure/tests/test_exposure.py
+@@ -12,7 +12,8 @@ from skimage._shared._warnings import expected_warnings
+ from skimage._shared import testing
+ from skimage._shared.testing import (assert_array_equal,
+                                      assert_array_almost_equal,
+-                                     assert_almost_equal)
++                                     assert_almost_equal,
++                                     numpy_uses_mkl, xfail)
+ 
+ 
+ # Test integer histograms
+@@ -191,6 +192,8 @@ def test_rescale_uint14_limits():
+ # Test adaptive histogram equalization
+ # ====================================
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_grayscale():
+     """Test a grayscale float image
+     """
+@@ -205,6 +208,8 @@ def test_adapthist_grayscale():
+     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
+ 
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_color():
+     """Test an RGB color uint16 image
+     """
+@@ -225,6 +230,8 @@ def test_adapthist_color():
+     return data, adapted
+ 
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_alpha():
+     """Test an RGBA color image
+     """
+diff --git a/skimage/restoration/tests/test_denoise.py b/skimage/restoration/tests/test_denoise.py
+index 2666a93..3ff2505 100644
+--- a/skimage/restoration/tests/test_denoise.py
++++ b/skimage/restoration/tests/test_denoise.py
+@@ -7,7 +7,8 @@ import pywt
+ 
+ from skimage._shared import testing
+ from skimage._shared.testing import (assert_equal, assert_almost_equal,
+-                                     assert_warns, assert_)
++                                     assert_warns, assert_,
++                                     numpy_uses_mkl, xfail)
+ from skimage._shared._warnings import expected_warnings
+ from distutils.version import LooseVersion as Version
+ 
+@@ -47,6 +48,8 @@ def test_denoise_tv_chambolle_2d():
+     assert_(np.sqrt((grad_denoised**2).sum()) < np.sqrt((grad**2).sum()))
+ 
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_denoise_tv_chambolle_multichannel():
+     denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1)
+     denoised = restoration.denoise_tv_chambolle(astro, weight=0.1,
+-- 
+2.19.1
+

--- a/recipe/0002-Mark-test_adapthist-as-xfail-if-numpy-uses-mkl.patch
+++ b/recipe/0002-Mark-test_adapthist-as-xfail-if-numpy-uses-mkl.patch
@@ -1,0 +1,67 @@
+From 5c5c932033c66507b966abf504b8a995fa0f15e0 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 11 Dec 2018 21:06:36 -0600
+Subject: [PATCH 2/2] Mark test_adapthist* as xfail if numpy uses mkl
+
+---
+ skimage/_shared/testing.py              | 2 ++
+ skimage/exposure/tests/test_exposure.py | 9 ++++++++-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/skimage/_shared/testing.py b/skimage/_shared/testing.py
+index b75123d..be82887 100644
+--- a/skimage/_shared/testing.py
++++ b/skimage/_shared/testing.py
+@@ -37,6 +37,8 @@ fixture = pytest.fixture
+ # https://docs.python.org/2/library/struct.html
+ arch32 = struct.calcsize("P") * 8 == 32
+ 
++numpy_uses_mkl = any(x.startswith('mkl') for x in
++    np.__config__.get_info('blas_opt')['libraries'])
+ 
+ def assert_less(a, b, msg=None):
+     message = "%r is not lower than %r" % (a, b)
+diff --git a/skimage/exposure/tests/test_exposure.py b/skimage/exposure/tests/test_exposure.py
+index 48e256e..7b63393 100644
+--- a/skimage/exposure/tests/test_exposure.py
++++ b/skimage/exposure/tests/test_exposure.py
+@@ -12,7 +12,8 @@ from skimage._shared._warnings import expected_warnings
+ from skimage._shared import testing
+ from skimage._shared.testing import (assert_array_equal,
+                                      assert_array_almost_equal,
+-                                     assert_almost_equal)
++                                     assert_almost_equal,
++                                     numpy_uses_mkl, xfail)
+ 
+ 
+ # Test integer histograms
+@@ -191,6 +192,8 @@ def test_rescale_uint14_limits():
+ # Test adaptive histogram equalization
+ # ====================================
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_grayscale():
+     """Test a grayscale float image
+     """
+@@ -205,6 +208,8 @@ def test_adapthist_grayscale():
+     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
+ 
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_color():
+     """Test an RGB color uint16 image
+     """
+@@ -225,6 +230,8 @@ def test_adapthist_color():
+     return data, adapted
+ 
+ 
++@xfail(condition=numpy_uses_mkl,
++       reason="mkl has precision problems")
+ def test_adapthist_alpha():
+     """Test an RGBA color image
+     """
+-- 
+2.19.1
+

--- a/recipe/3458.patch
+++ b/recipe/3458.patch
@@ -1,0 +1,65 @@
+From c0c2c5dd552fdd0a2c5e0771399999b158cbcc5c Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Mon, 8 Oct 2018 23:24:30 -0400
+Subject: [PATCH] TST: don't use the pytest.fixtures decorator anymore in class
+ fixtures as explained by a pytest warning
+
+RemovedInPytest4Warning: Fixture "setUp" called directly. Fixtures are
+not meant to be called directly, are created automatically when test
+functions request them as parameters. See
+https://docs.pytest.org/en/latest/fixture.html for more information.
+---
+ skimage/filters/tests/test_lpi_filter.py | 1 -
+ skimage/io/tests/test_collection.py      | 1 -
+ skimage/io/tests/test_multi_image.py     | 1 -
+ skimage/morphology/tests/test_grey.py    | 1 -
+ 4 files changed, 4 deletions(-)
+
+diff --git a/skimage/filters/tests/test_lpi_filter.py b/skimage/filters/tests/test_lpi_filter.py
+index 34a87ac0bd..90043b34dc 100644
+--- a/skimage/filters/tests/test_lpi_filter.py
++++ b/skimage/filters/tests/test_lpi_filter.py
+@@ -23,7 +23,6 @@ class TestLPIFilter2D(unittest.TestCase):
+     def filt_func(self, r, c):
+         return np.exp(-np.hypot(r, c) / 1)
+ 
+-    @testing.fixture(autouse=True)
+     def setUp(self):
+         self.f = LPIFilter2D(self.filt_func)
+ 
+diff --git a/skimage/io/tests/test_collection.py b/skimage/io/tests/test_collection.py
+index 7cdcfc1ad6..a053a09add 100644
+--- a/skimage/io/tests/test_collection.py
++++ b/skimage/io/tests/test_collection.py
+@@ -32,7 +32,6 @@ class TestImageCollection(TestCase):
+     pattern_matched = [os.path.join(data_dir, pic)
+                        for pic in ['camera.png', 'moon.png']]
+ 
+-    @testing.fixture(autouse=True)
+     def setUp(self):
+         reset_plugins()
+         # Generic image collection with images of different shapes.
+diff --git a/skimage/io/tests/test_multi_image.py b/skimage/io/tests/test_multi_image.py
+index 0a6aeef5c0..c166852895 100644
+--- a/skimage/io/tests/test_multi_image.py
++++ b/skimage/io/tests/test_multi_image.py
+@@ -10,7 +10,6 @@
+ 
+ 
+ class TestMultiImage(TestCase):
+-    @testing.fixture(autouse=True)
+     def setUp(self):
+         # This multipage TIF file was created with imagemagick:
+         # convert im1.tif im2.tif -adjoin multipage.tif
+diff --git a/skimage/morphology/tests/test_grey.py b/skimage/morphology/tests/test_grey.py
+index 07f900aeca..e1632ff1a2 100644
+--- a/skimage/morphology/tests/test_grey.py
++++ b/skimage/morphology/tests/test_grey.py
+@@ -50,7 +50,6 @@ def test_gray_morphology(self):
+ 
+ 
+ class TestEccentricStructuringElements(TestCase):
+-    @testing.fixture(autouse=True)
+     def setUp(self):
+         self.black_pixel = 255 * np.ones((4, 4), dtype=np.uint8)
+         self.black_pixel[1, 1] = 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.14.1" %}
+{% set version = "0.14.2" %}
 
 package:
   name: scikit-image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
-  sha256: 86a9b3b4f74f231e0a6bcfd3235dcf3f0118df25dac21201da5e064d681e2c50
+  git_url: https://github.com/scikit-image/scikit-image
+  git_tag: v{{ version }}
 
 build:
   number: 1001
@@ -68,6 +68,8 @@ extra:
     - ivoflipse
     - jakirkham
     - jni
+    - Korijn
+    - mingwandroid
     - msarahan
     - ocefpaf
     - soupault

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ test:
 about:
   home: http://scikit-image.org/
   license: BSD 3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: 'Image processing routines for SciPy.'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,13 @@ package:
 source:
   git_url: https://github.com/scikit-image/scikit-image
   git_tag: v{{ version }}
+  patches:
+    - 3458.patch
+    - 0001-_marching_cubes_lewiner_cy-mark-char-as-signed.patch
+    - 0002-Mark-some-tests-as-xfail-if-numpy-uses-mkl.patch
 
 build:
-  number: 1001
+  number: 0
   script:
     - rm -rf skimage/viewer/tests  # we don't depend on Qt
     - python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 1001
   script:
     - rm -rf skimage/viewer/tests  # we don't depend on Qt
-    - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    - python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - skivi = skimage.scripts.skivi:main
 


### PR DESCRIPTION
Please update to 0.14.2.

0.14.1 is not installable with scikit-image

https://github.com/scikit-image/scikit-image/issues/3780


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
