### PR TITLE
update 0.19.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ source:
 build:
   number: {{ build_number }}
   skip: true  # [py<37]
-  # There isn't currently available tifffile >=2019.7.26 on win32 
   entry_points:
     - skivi = skimage.scripts.skivi:main
 
@@ -33,8 +32,8 @@ requirements:
     - python
     - cython >=0.29.24,<3.0
     - llvm-openmp >=4.0.01  # [osx]
-    - numpy   1.19  # [py==38 or py==39]
-    - numpy   1.21  # [py==310]
+    - numpy   1.19  # [py<310]
+    - numpy   1.21  # [py>=310]
     - packaging
     - pip
     - pythran

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   number: {{ build_number }}
   skip: true  # [py<37]
   # There isn't currently available tifffile >=2019.7.26 on win32 
-  skip: true  # [win32]
   entry_points:
     - skivi = skimage.scripts.skivi:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - imageio >=2.4.1
+    - imageio >=2.16.2
     - llvm-openmp >=4.0.1  # [osx]
     # pin to older networkx<2.7 for Python 3.7 as it requires SciPy>=1.8 which
     # is only available for Python>=3.8.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,9 +63,7 @@ requirements:
     - cytoolz >=0.7.3  # [python_impl == 'cpython']
     # cloudpickle is necessary to provide the 'processes' scheduler for dask
     - cloudpickle >=0.2.1
-    # Using selector until packages for other platforms are (re)built using
-    # newer "defaults" toolchains that use the `_openmp_mutex` mechanism.
-    - _openmp_mutex  # [linux and (not ppc64le)]
+    - _openmp_mutex  # [linux]
   run_constrained:
     - matplotlib-base >=3.0.3
     - pooch >=1.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - python
     - cython >=0.29.24,<3.0
     - llvm-openmp >=4.0.01  # [osx]
-    - numpy
+    - numpy   1.19  # [py==38 or py==39]
+    - numpy   1.21  # [py==310]
     - packaging
     - pip
     - pythran

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,10 @@
-{% set version = "0.19.2" %}
-{% set sha256 = "d433b4642a6f8219e749dfbbe4b5e742d560996540c9749ede510274d061866d" %}
+{% set name = "scikit-image" %}
+{% set version = "0.19.3" %}
+{% set sha256 = "24b5367de1762da6ee126dd8f30cc4e7efda474e0d7d70685433f0e3aa2ec450" %}
+{% set build_number = "0" %}
 
 package:
-  name: scikit-image
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -12,7 +14,7 @@ source:
     - skip-broken-tests.patch
 
 build:
-  number: 0
+  number: {{ build_number }}
   skip: true  # [py<37]
   # There isn't currently available tifffile >=2019.7.26 on win32 
   skip: true  # [win32]
@@ -43,7 +45,10 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - imageio >=2.4.1
     - llvm-openmp >=4.0.1  # [osx]
-    - networkx >=2.2
+    # pin to older networkx<2.7 for Python 3.7 as it requires SciPy>=1.8 which
+    # is only available for Python>=3.8.
+    - networkx >=2.2,<2.7   # [py<=37]
+    - networkx >=2.2        # [py>37]
     - packaging >=20.0
     - pillow >=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
     - pywavelets >=1.1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,8 @@ requirements:
     - imageio >=2.16.2
     - llvm-openmp >=4.0.1  # [osx]
     # pin to older networkx<2.7 for Python 3.7 as it requires SciPy>=1.8 which
-    # is only available for Python>=3.8.
+    # is only available for Python>=3.8
+    # https://github.com/conda-forge/scikit-image-feedstock/pull/91
     - networkx >=2.2,<2.7   # [py<=37]
     - networkx >=2.2        # [py>37]
     - packaging >=20.0


### PR DESCRIPTION
Changelog:
- update version and checksum, reset build number
- update networkx pin to match [changes made in conda-forge](https://github.com/conda-forge/scikit-image-feedstock/pull/91)
- update imageio pin for the fixed array reshaping in legacy_pillow.py (you can find out more about this [here](https://github.com/imageio/imageio/commit/309242d42bf43103290ee57934e9b64abd0fac9f))
- removed `not ppc64le` selector from `_openmp_mutex`