### PR TITLE
scikit-image 0.24.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,9 +94,14 @@ test:
     - astropy >=5.0
     - dask-core >=2021.1.0
     #- pytest-faulthandler
+    # RuntimeWarning: networkx backend defined more than once: nx-loopback,
+    # see https://github.com/networkx/networkx/issues/7101 and https://github.com/python/importlib_metadata/pull/381/files
+    - importlib_metadata >=4.11.4  # [py<310]
   commands:
     - pip check
     - python -c "import skimage; print(skimage.__version__)"
+    # Check if the nx-loopback entry point is registered twice
+    - python -c "from importlib.metadata import entry_points; print(entry_points()['networkx.backends'])"  # [py<310]
     - set OPENBLAS_NUM_THREADS=1          # [win]
     - set OMP_NUM_THREADS=1               # [win]
     - export OPENBLAS_NUM_THREADS=1       # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-image" %}
-{% set version = "0.23.2" %}
+{% set version = "0.24.0" %}
 
 
 package:
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://github.com/scikit-image/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: be1b8d38fb51b8076d829f682646f9fdb61f9936e43a8b775fb594c7c7930a88
+  sha256: a2cf85577f8a9105ac46130277ad27e1627bfa3effecff7c1ef3ea851e5671ba
 
 build:
   number: 0
-  skip: true  # [py<310]
+  skip: true  # [py<39]
   entry_points:
     - skivi = skimage.scripts.skivi:main
 
@@ -72,6 +72,10 @@ requirements:
 # known to be broken on s390x: if platform.machine() == "s390x" and plugin == "pil" and fmt == "png"
 {% set tests_to_skip = tests_to_skip + " or test_all_mono" %}          # [linux and s390x]
 
+# Don't test thresholding funcs for Dask compatibility, see https://github.com/scikit-image/scikit-image/pull/7509.
+# Remove it with a new scikit-image release >=0.25.0.
+{% set tests_to_skip = tests_to_skip + " or test_thresholds_dask_compatibility" %}
+
 test:
   imports:
     - skimage
@@ -86,7 +90,6 @@ test:
     - scikit-learn
     - numpydoc >=1.7
     - pytest >=7.0
-    - pytest-cov >=2.11.0
     - pytest-localserver
     - astropy >=5.0
     - dask-core >=2021.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
   url: https://github.com/scikit-image/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: a2cf85577f8a9105ac46130277ad27e1627bfa3effecff7c1ef3ea851e5671ba
   patches:                     # [py<310]
-    # Suppress the warning (pollutes CI) for py<310.
+    # Suppress the warning (pollutes CI) for py<310
+    # because of RuntimeWarning: networkx backend defined more than once: nx-loopback,
+    # see https://github.com/networkx/networkx/issues/7101 and https://github.com/python/importlib_metadata/pull/381/files
     - suppress_warnings.patch  # [py<310]
 
 build:
@@ -97,14 +99,9 @@ test:
     - astropy >=5.0
     - dask-core >=2021.1.0
     #- pytest-faulthandler
-    # RuntimeWarning: networkx backend defined more than once: nx-loopback,
-    # see https://github.com/networkx/networkx/issues/7101 and https://github.com/python/importlib_metadata/pull/381/files
-    - importlib_metadata >=4.11.4  # [py<310]
   commands:
     - pip check
     - python -c "import skimage; print(skimage.__version__)"
-    # Check if the nx-loopback entry point is registered twice
-    - python -c "from importlib.metadata import entry_points; print(entry_points()['networkx.backends'])"  # [py<310]
     - set OPENBLAS_NUM_THREADS=1          # [win]
     - set OMP_NUM_THREADS=1               # [win]
     - export OPENBLAS_NUM_THREADS=1       # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,8 @@ test:
     - python -c "import skimage; print(skimage.__version__)"
     # Check if the nx-loopback entry point is registered twice
     - python -c "from importlib.metadata import entry_points; print(entry_points()['networkx.backends'])"  # [py<310]
+    # Suppress the warning (pollutes CI).
+    - python py_tests.py  # [py<310]
     - set OPENBLAS_NUM_THREADS=1          # [win]
     - set OMP_NUM_THREADS=1               # [win]
     - export OPENBLAS_NUM_THREADS=1       # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,8 @@ test:
     - skimage
   source_files:
     - pyproject.toml
+  files:           # [py<310]
+    - py_tests.py  # [py<310]
   requires:
     - pip
     - pooch >=1.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,9 @@ package:
 source:
   url: https://github.com/scikit-image/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: a2cf85577f8a9105ac46130277ad27e1627bfa3effecff7c1ef3ea851e5671ba
+  patches:                     # [py<310]
+    # Suppress the warning (pollutes CI) for py<310.
+    - suppress_warnings.patch  # [py<310]
 
 build:
   number: 0
@@ -81,8 +84,6 @@ test:
     - skimage
   source_files:
     - pyproject.toml
-  files:           # [py<310]
-    - py_tests.py  # [py<310]
   requires:
     - pip
     - pooch >=1.6.0
@@ -104,8 +105,6 @@ test:
     - python -c "import skimage; print(skimage.__version__)"
     # Check if the nx-loopback entry point is registered twice
     - python -c "from importlib.metadata import entry_points; print(entry_points()['networkx.backends'])"  # [py<310]
-    # Suppress the warning (pollutes CI).
-    - python py_tests.py  # [py<310]
     - set OPENBLAS_NUM_THREADS=1          # [win]
     - set OMP_NUM_THREADS=1               # [win]
     - export OPENBLAS_NUM_THREADS=1       # [not win]

--- a/recipe/py_tests.py
+++ b/recipe/py_tests.py
@@ -1,0 +1,5 @@
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="networkx backend defined more than once: nx-loopback")
+    import networkx as nx

--- a/recipe/py_tests.py
+++ b/recipe/py_tests.py
@@ -1,5 +1,0 @@
-import warnings
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", message="networkx backend defined more than once: nx-loopback")
-    import networkx as nx

--- a/recipe/suppress_warnings.patch
+++ b/recipe/suppress_warnings.patch
@@ -1,0 +1,46 @@
+From f73c5ebb19b9e9b5e7ae61ed174ed34c40d54907 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Mon, 16 Sep 2024 17:59:37 +0300
+Subject: [PATCH] Suppress warnings
+
+---
+ skimage/graph/tests/test_rag.py    | 6 ++++++
+ skimage/util/tests/test_lookfor.py | 6 ++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/skimage/graph/tests/test_rag.py b/skimage/graph/tests/test_rag.py
+index 6c223a5e4..d03c0f13c 100644
+--- a/skimage/graph/tests/test_rag.py
++++ b/skimage/graph/tests/test_rag.py
+@@ -5,6 +5,12 @@ from skimage import graph
+ from skimage import segmentation, data
+ from skimage._shared import testing
+ 
++import warnings
++
++with warnings.catch_warnings():
++    warnings.filterwarnings("ignore", message="networkx backend defined more than once: nx-loopback")
++    import networkx as nx
++
+ 
+ def max_edge(g, src, dst, n):
+     default = {'weight': -np.inf}
+diff --git a/skimage/util/tests/test_lookfor.py b/skimage/util/tests/test_lookfor.py
+index 7bdb5ba58..07dadd3fd 100644
+--- a/skimage/util/tests/test_lookfor.py
++++ b/skimage/util/tests/test_lookfor.py
+@@ -1,5 +1,11 @@
+ import skimage as ski
+ 
++import warnings
++
++with warnings.catch_warnings():
++    warnings.filterwarnings("ignore", message="networkx backend defined more than once: nx-loopback")
++    import networkx as nx
++
+ 
+ def test_lookfor_basic(capsys):
+     assert ski.lookfor is ski.util.lookfor
+-- 
+2.46.0
+


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5594](https://anaconda.atlassian.net/browse/PKG-5594) 
- [Upstream repository](https://github.com/scikit-image/scikit-image/tree/v0.24.0)
- release notes: https://github.com/scikit-image/scikit-image/releases
- Requirements: 
  - https://github.com/scikit-image/scikit-image/tree/v0.24.0/requirements
  - https://github.com/scikit-image/scikit-image/blob/v0.24.0/pyproject.toml

### Explanation of changes:

- Apply a patch to suppress the warning `RuntimeWarning: networkx backend defined more than once: nx-loopback` that pollutes our CI for **py<310**, see https://github.com/networkx/networkx/issues/7101 and https://github.com/python/importlib_metadata/pull/381/files. `Cpython` changed that behavior in **py>=310**, see https://github.com/python/cpython/commit/f917efccf8d5aa2b8315d2a832a520339e668187
- Don't test thresholding funcs for Dask compatibility, see https://github.com/scikit-image/scikit-image/pull/7509
- Remove `pytest-cov` from `test/requires`

### Notes:

-

[PKG-5594]: https://anaconda.atlassian.net/browse/PKG-5594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ