### PR TITLE
scikit-image 0.25.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+pbp_autopublish: false
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,5 +15,5 @@ set "LDFLAGS="
 REM don't add d1trimfile option because clang doesn't recognize it.
 set "SRC_DIR="
 
-%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+%PYTHON% -m pip install . -vvv --no-deps --no-build-isolation
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,5 +15,6 @@ set "LDFLAGS="
 REM don't add d1trimfile option because clang doesn't recognize it.
 set "SRC_DIR="
 
-%PYTHON% -m pip install . -vvv --no-deps --no-build-isolation
+REM Adding --config-settings=compile-args="-j4" to make the windows build more stable for meson-python and cython compilation.
+%PYTHON% -m pip install . -vvv --no-deps --no-build-isolation --config-settings=compile-args="-j4"
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,10 +2,6 @@ set -ex
 
 cd ${SRC_DIR}
 
-if [[ ${target_platform} == linux-ppc64le ]]; then
-  export OPENBLAS_NUM_THREADS=2
-fi
-
 # clean any cython-generated .c/.cpp files (as used by "make clean")
 find . -name "*.pyx" -exec ./tools/rm_pyx_assoc_c_cpp.sh {} \;
 ${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-image" %}
-{% set version = "0.24.0" %}
+{% set version = "0.25.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/scikit-image/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a2cf85577f8a9105ac46130277ad27e1627bfa3effecff7c1ef3ea851e5671ba
+  sha256: 7e7ec5cdac70f6df2dd6151cc27d4b8b6f2e029b4485b7635bb9522dc7023ddb
   patches:                     # [py<310]
     # Suppress the warning (pollutes CI) for py<310
     # because of RuntimeWarning: networkx backend defined more than once: nx-loopback,
@@ -17,7 +17,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   entry_points:
     - skivi = skimage.scripts.skivi:main
 
@@ -30,32 +30,35 @@ requirements:
     - {{ compiler("cxx") }}
   host:
     - python
-    - cython >=3.0.4
-    - numpy {{ numpy }}
+    - cython >=3.0.8
+    - numpy 2
     - packaging
     - pip
-    - pythran
-    - meson-python >=0.15
-    - lazy_loader >=0.3
+    - pythran >=0.16
+    - meson-python >=0.16
+    - lazy_loader >=0.4
+    - setuptools >=68
   run:
     - python
-    - {{ pin_compatible('numpy', lower_bound='1.23') }}
-    - scipy >=1.9
-    - networkx >=2.8
-    - pillow >=9.1
-    - imageio >=2.33
+    - numpy >=1.24,<3
+    - scipy >=1.11.2
+    - networkx >=3.0
+    - pillow >=10.1
+    - imageio >=2.33,!=2.35.0
     - tifffile >=2022.8.12
     - packaging >=21
     - lazy_loader >=0.4
     - _openmp_mutex  # [linux]
   run_constrained:
-    - matplotlib-base >=3.6
+    - matplotlib-base >=3.7
     - pooch >=1.6.0
+    - pyamg >=5.2
     - astropy >=5.0
     - scikit-learn >=1.1
-    - pywavelets >=1.1.1
+    - pywavelets >=1.6
+    - scikit-learn >=1.2
     - cloudpickle >=0.2.1
-    - dask-core >=2021.1.0
+    - dask-core >=2021.1.0,!=2024.8.0
 
 {% set tests_to_skip = "_not_a_real_test" %}
 
@@ -81,6 +84,9 @@ requirements:
 # see https://github.com/scikit-image/scikit-image/pull/7509.
 # Remove it with a new scikit-image release >=0.25.0.
 {% set tests_to_skip = tests_to_skip + " or test_thresholds_dask_compatibility" %}
+
+# see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408 
+{% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,10 @@ requirements:
 # see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408 
 {% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}
 
+# tifffile uses deprecated attribute `ndarray.newbyteorder` (for py313)
+{% set tests_to_skip = tests_to_skip + " or test_kidney_3d_multichannel or test_lily_multichannel" %}  # [py>=313]
+
+
 test:
   imports:
     - skimage
@@ -100,12 +104,12 @@ test:
     - matplotlib-base
     - pywavelets
     - scikit-learn
+    # TODO: Remove the selector when numpydoc and astropy will have py313 support on the main channel
     - numpydoc >=1.7  # [py<313]
+    - astropy >=5.0   # [py<313]
     - pytest >=7.0
     - pytest-localserver
-    - astropy >=5.0  # [py<313]
     - dask-core >=2021.1.0
-    #- pytest-faulthandler
   commands:
     - pip check
     - python -c "import skimage; print(skimage.__version__)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,6 @@ package:
 source:
   url: https://github.com/scikit-image/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 7e7ec5cdac70f6df2dd6151cc27d4b8b6f2e029b4485b7635bb9522dc7023ddb
-  patches:                     # [py<310]
-    # Suppress the warning (pollutes CI) for py<310
-    # because of RuntimeWarning: networkx backend defined more than once: nx-loopback,
-    # see https://github.com/networkx/networkx/issues/7101 and https://github.com/python/importlib_metadata/pull/381/files
-    - suppress_warnings.patch  # [py<310]
 
 build:
   number: 0
@@ -56,7 +51,6 @@ requirements:
     - pooch >=1.6.0
     - pyamg >=5.2
     - astropy >=5.0
-    - scikit-learn >=1.1
     - pywavelets >=1.6
     - scikit-learn >=1.2
     - cloudpickle >=0.2.1
@@ -88,7 +82,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_thresholds_dask_compatibility" %}
 
 # see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408 
-{% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}
+{% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}  # [osx]
 
 # tifffile uses deprecated attribute `ndarray.newbyteorder` (for py313)
 {% set tests_to_skip = tests_to_skip + " or test_kidney_3d_multichannel or test_lily_multichannel" %}  # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,10 +100,10 @@ test:
     - matplotlib-base
     - pywavelets
     - scikit-learn
-    - numpydoc >=1.7
+    - numpydoc >=1.7  # [py<313]
     - pytest >=7.0
     - pytest-localserver
-    - astropy >=5.0
+    - astropy >=5.0  # [py<313]
     - dask-core >=2021.1.0
     #- pytest-faulthandler
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,17 +28,17 @@ requirements:
     - lld                   # [win]
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - ninja
     - pkg-config
   host:
     - python
     - cython >=3.0.8
+    - lazy_loader >=0.4
+    - meson-python >=0.16
+    - ninja 1.12.1
     - numpy 2
     - packaging
     - pip
     - pythran >=0.16
-    - meson-python >=0.16
-    - lazy_loader >=0.4
     - setuptools >=68
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - cython >=3.0.8
     - lazy_loader >=0.4
     - meson-python >=0.16
-    - ninja 1.12.1
+    - ninja-base 1.12.1
     - numpy 2
     - packaging
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,8 +81,9 @@ requirements:
 # Remove it with a new scikit-image release >=0.25.0.
 {% set tests_to_skip = tests_to_skip + " or test_thresholds_dask_compatibility" %}
 
-# see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408 
-{% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}  # [osx]
+# ValueError: Output dtype not compatible with inputs (failed on all platforms),
+# see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408
+{% set tests_to_skip = tests_to_skip + " or test_2d_bf[float16] or test_2d_cg[float16] or test_2d_cg_mg[float16] or test_2d_cg_j[float16]" %}
 
 # tifffile uses deprecated attribute `ndarray.newbyteorder` (for py313)
 {% set tests_to_skip = tests_to_skip + " or test_kidney_3d_multichannel or test_lily_multichannel" %}  # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - lld                   # [win]
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - ninja
+    - pkg-config
   host:
     - python
     - cython >=3.0.8
@@ -91,6 +93,8 @@ requirements:
 # tifffile uses deprecated attribute `ndarray.newbyteorder` (for py313)
 {% set tests_to_skip = tests_to_skip + " or test_kidney_3d_multichannel or test_lily_multichannel" %}  # [py>=313]
 
+# AssertionError: Arrays are not almost equal to 7 decimals. Possible, it's a numpy compatibility issue
+{% set tests_to_skip = tests_to_skip + " or test_are or test_rag_boundary" %}  # [osx and x86_64]
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-PKG-6641](https://anaconda.atlassian.net/browse/PKG-6641) 
- [Upstream repository](https://github.com/scikit-image/scikit-image/tree/v0.25.0)
- release notes: https://github.com/scikit-image/scikit-image/releases
- Requirements: 
  - https://github.com/scikit-image/scikit-image/tree/v0.25.0/requirements
  - https://github.com/scikit-image/scikit-image/blob/v0.25.0/pyproject.toml

### Explanation of changes:

- Skip `py<310`
- Add `ninja-base 1.12.1` explicitly to `host` (the pip install runs it implicitly). It won't work if we put it to `build`.
- Update pinnings
- Skip some tests because of issues with:
  - float16 (won't fixed by the upstream source, see https://github.com/scipy/scipy/issues/20200 and https://github.com/scipy/scipy/issues/7408)
  - tifffile uses deprecated attribute `ndarray.newbyteorder` (for py313)
  - AssertionError: Arrays are not almost equal to 7 decimals. Possible, it's a numpy compatibility issue on osx-64 only
  - numpydoc and astropy tests for py313 because there are no py313 artifacts on the main channel

### Notes:

- compilation on win64 can fail sporadically only for py312 with this error:
```
2025-01-16 13:56:00.309097+00:00 INFO   [22/165] Generating 
'skimage\\graph\\_ncut_cy.cp312-win_amd64.pyd.p\\_ncut_cy.c'
None INFO   FAILED: skimage/graph/_ncut_cy.cp312-win_amd64.pyd.p/_ncut_cy.c
None INFO   "python" "C:\b\abs_1afzuphu92\croot\scikit-image_1737032008167\work\skimage\_build_utils/cythoner.py" 
"../skimage/graph/_ncut_cy.pyx" "skimage/graph/_ncut_cy.cp312-win_amd64.pyd.p/_ncut_cy.c"
None INFO   Traceback (most recent call last):
None INFO     File "C:\b\abs_1afzuphu92\croot\scikit-image_1737032008167\work\skimage\_build_utils/cythoner.py", 
line 37, in <module>
None INFO       main()
None INFO       ~~~~^^
None INFO     File "C:\b\abs_1afzuphu92\croot\scikit-image_1737032008167\work\skimage\_build_utils/cythoner.py", 
line 20, in main
None INFO       sbp.run(
None INFO       ~~~~~~~^
None INFO           [
None INFO           ^
None INFO       ...<10 lines>...
None INFO           check=True,
None INFO           ^^^^^^^^^^^
None INFO       )
None INFO       ^
None INFO     File "C:\b\abs_1afzuphu92\croot\scikit-image_1737032008167\_build_env\Lib\subprocess.py", line 577, 
in run
None INFO       raise CalledProcessError(retcode, process.args,
None INFO                                output=stdout, stderr=stderr)
2025-01-16 13:56:02.733719+00:00 INFO   subprocess.CalledProcessError: Command '['cython', '-3', '--fast-fail', 
'--output-file', 
'C:\\b\\abs_1afzuphu92\\croot\\scikit-image_1737032008167\\work\\.mesonpy-slef7_es\\skimage\\graph\\_ncut_cy.cp312
-win_amd64.pyd.p\\_ncut_cy.c', '--include-dir', 
'C:\\b\\abs_1afzuphu92\\croot\\scikit-image_1737032008167\\work\\.mesonpy-slef7_es', 
'C:\\b\\abs_1afzuphu92\\croot\\scikit-image_1737032008167\\work\\skimage\\graph\\_ncut_cy.pyx']' returned non-zero
exit status 3221356611.

```
after reopening the PR or pushing a new commit, it can pass. The issue is intermittent because `meson-python` builds on Windows are unstable when calling `cython`.
